### PR TITLE
fix pandoc graphviz filter

### DIFF
--- a/PandocFilterGraphviz.hs
+++ b/PandocFilterGraphviz.hs
@@ -47,7 +47,7 @@ import           Data.Text.Encoding     as E
 import           System.Directory
 import           System.Exit
 import           System.FilePath
-import           System.Process         (readProcessWithExitCode, system)
+import           System.Process         (readProcess, system)
 
 import           Text.Pandoc
 import           Text.Pandoc.JSON
@@ -88,13 +88,13 @@ ensureFile fp =
 
 renderDot :: String -> FilePath -> IO FilePath
 renderDot src dst =
-  readProcessWithExitCode "dot" ["-Tsvg", "-o" ++ show dst, "-"] src >>
+  readProcess "dot" ["-Tsvg", "-o" ++ dst] src >>
   return dst
 
 -- Here is some msc rendering stuff
 renderMsc :: String -> FilePath -> IO FilePath
 renderMsc src dst =
-  readProcessWithExitCode "mscgen" ["-Tsvg", "-o" ++ show dst, "-"] src >>
+  readProcess "mscgen" ["-Tsvg", "-o" ++ dst] src >>
   return dst
 
 -- and we combine everything into one function
@@ -102,15 +102,13 @@ renderAll :: Block -> IO Block
 renderAll cblock@(CodeBlock (id, classes, attrs) content)
   | "msc" `elem` classes =
     let dest = fileName4Code "mscgen" (T.pack content) (Just "msc")
-     in do ensureFile dest >> writeFile dest content
+     in do ensureFile dest
            img <- renderMsc content dest
-           ensureFile img
            return $ image img
   | "graphviz" `elem` classes =
     let dest = fileName4Code "graphviz" (T.pack content) (Just "dot")
-     in do ensureFile dest >> writeFile dest content
+     in do ensureFile dest
            img <- renderDot content dest
-           ensureFile img
            return $ image img
   | otherwise = return cblock
   where


### PR DESCRIPTION
Thanks for open-sourcing your site, and for your most recent post! It gave me some interesting tools to blog with.

I wanted to set up a graphviz Pandoc filter on my own site, and couldn't make it work, so I looked at your site, and found I couldn't make it work, either. I think you may have the same problem I was having (https://www.justus.pw/posts/2018-04-20-smart-contract-ownership.html has a broken image link). I have graphviz 2.41, installed with `brew install graphviz` on a mac.

To reproduce:
run `stack build && stack exec site watch`
navigate to http://127.0.0.1:8000/posts/2018-04-20-smart-contract-ownership.html and see that the graphviz image doesn't show up correctly.

This code was running `readProcessWithExitCode`, but failing silently by ignoring the exit code. I replaced it with something that would explode in case there are future problems there.

 